### PR TITLE
Add analog reading command 'a'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A simple commandline to scan I2C, read/write GPIO, read/write EEPROM and read CP
 | `^` | Set a port LOW-HIGH-LOW (one clock) | `^ 7` (sends a clock pulse to pin 7) |
 | `$` | Do a pin sweep | `$` |
 | `c` | Set port to clock high and low with given duration | `c 8 100` (clocks pin 8 with 100ms duration)|
+| `a` | Analog reading | `a 0` or `a a0` (reads analog value from pin A0) |
 | `g` | Set analog (pwm) value | `g 9 128` (sets PWM on pin 9 to 128)|
 | `s` | Set servo value | `s 10 90` (sets servo on pin 10 to 90 degrees)|
 | `\A2/A3`| Set Pin A2 to low, Pin A3 to high (and both to output) | `\A2/A3` |

--- a/examples/Minipirate/Minipirate.ino
+++ b/examples/Minipirate/Minipirate.ino
@@ -106,6 +106,7 @@ void mpHelp() {
   SERIAL_PRINTLN_PGM("c - Set port to clock high and low with given delay");
 
   // Serial.println("b - Show bar graph of analog input");
+  SERIAL_PRINTLN_PGM("a - Analog reading");
   SERIAL_PRINTLN_PGM("g - Set analog (pwm) value");
 
   SERIAL_PRINTLN_PGM("s - Set servo value");
@@ -376,6 +377,38 @@ void loop()
       }
      }
      break;
+    case 'a':
+     {
+       Serial.println();
+       int pin_nbre = pollPin();
+       int analog_channel = -1;
+       if (pin_nbre >= A0 && pin_nbre < A0 + NUM_ANALOG_INPUTS) {
+         analog_channel = pin_nbre - A0;
+       } else if (pin_nbre >= 0 && pin_nbre < NUM_ANALOG_INPUTS) {
+         analog_channel = pin_nbre;
+         pin_nbre = A0 + pin_nbre;
+       }
+
+       if (analog_channel >= 0) {
+         int a_value = analogRead(analog_channel);
+         SERIAL_PRINT_PGM("Analog value on pin ");
+         printPin(pin_nbre);
+         printStrDec(": ", a_value);
+         SERIAL_PRINT_PGM(" / ");
+         Serial.print(a_value / 1023.0f * VCC);
+         SERIAL_PRINTLN_PGM("V");
+       } else {
+         SERIAL_PRINT_PGM("Pin ");
+         if (pin_nbre >= 0) {
+           printPin(pin_nbre);
+         } else {
+           SERIAL_PRINT_PGM("invalid");
+         }
+         SERIAL_PRINTLN_PGM(" does not support analog input");
+       }
+     }
+    break;
+
     case 'g':
      {
        int pin_nbre = pollPin();

--- a/examples/Minipirate/modeI2C.cpp
+++ b/examples/Minipirate/modeI2C.cpp
@@ -17,8 +17,7 @@
 #include <Arduino.h>
 #include "baseIO.h"
 #include "modeI2C.h"
-// #include <Wire.h>
-#include "../Wire/Wire.h" // Hack: See http://forum.arduino.cc/index.php/topic,42818.0.html#5
+#include <Wire.h>
 
 
 void ModeI2C::setup() {


### PR DESCRIPTION
This PR adds support for reading analog pin values using the 'a' command. It parses the pin number, validates it, and reads/converts the voltage, printing both raw ADC value and Volts. It also updates documentation and modernizes Wire.h inclusion.

Fixes #24

---
*PR created automatically by Jules for task [5101363591950878378](https://jules.google.com/task/5101363591950878378) started by @chatelao*