### PR TITLE
Add support for the RP2040 and RP2350 boards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,9 @@ jobs:
 
       - name: Install platform and libraries
         run: |
-          arduino-cli core update-index
+          arduino-cli core update-index --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
           arduino-cli core install arduino:avr
+          arduino-cli core install rp2040:rp2040 --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
           arduino-cli lib install Servo
 
       - name: Link library
@@ -27,3 +28,5 @@ jobs:
       - name: Compile Sketch
         run: |
           arduino-cli compile --fqbn arduino:avr:uno examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn rp2040:rp2040:rpipico examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn rp2040:rp2040:rpipico2 examples/Minipirate/Minipirate.ino

--- a/examples/Minipirate/Minipirate.ino
+++ b/examples/Minipirate/Minipirate.ino
@@ -27,7 +27,9 @@
 #ifdef __AVR__
 #include <EEPROM.h>
 #else
+#ifndef NUM_DIGITAL_PINS
 #define NUM_DIGITAL_PINS 10
+#endif
 #endif
 #ifndef ESP8266
 #include <Servo.h>

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Commandline for GPIO, I2C and CPU manipulations
 paragraph=To scan I2C, read/write GPIO, read/write EEPROM and read CPU informations from any Serial terminal. Ideal for exploring new devices without any code writing.
 category=Device Control
 url=https://github.com/chatelao/MiniPirate
-architectures=avr,samd
+architectures=avr,samd,rp2040


### PR DESCRIPTION
This patch adds support for RP2040 and RP2350 boards to SwissHandmade MiniPirate. It includes configuration changes to library.properties, resolves compilation issues, and updates GitHub Actions builds to compile and verify against RP2040 and RP2350 targets.

Fixes #25

---
*PR created automatically by Jules for task [5160147317422641518](https://jules.google.com/task/5160147317422641518) started by @chatelao*