### PR TITLE
Add continuous analog reading via 'aa' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A simple commandline to scan I2C, read/write GPIO, read/write EEPROM and read CP
 | `$` | Do a pin sweep | `$` |
 | `c` | Set port to clock high and low with given duration | `c 8 100` (clocks pin 8 with 100ms duration)|
 | `a` | Analog reading | `a 0` or `a a0` (reads analog value from pin A0) |
+| `aa` | Continuous analog reading | `aa` or `aa 100` (continuous reading of analog values) |
 | `g` | Set analog (pwm) value | `g 9 128` (sets PWM on pin 9 to 128)|
 | `s` | Set servo value | `s 10 90` (sets servo on pin 10 to 90 degrees)|
 | `\A2/A3`| Set Pin A2 to low, Pin A3 to high (and both to output) | `\A2/A3` |

--- a/examples/Minipirate/Minipirate.ino
+++ b/examples/Minipirate/Minipirate.ino
@@ -107,6 +107,7 @@ void mpHelp() {
 
   // Serial.println("b - Show bar graph of analog input");
   SERIAL_PRINTLN_PGM("a - Analog reading");
+  SERIAL_PRINTLN_PGM("aa - Continuous analog reading");
   SERIAL_PRINTLN_PGM("g - Set analog (pwm) value");
 
   SERIAL_PRINTLN_PGM("s - Set servo value");
@@ -379,32 +380,61 @@ void loop()
      break;
     case 'a':
      {
-       Serial.println();
-       int pin_nbre = pollPin();
-       int analog_channel = -1;
-       if (pin_nbre >= A0 && pin_nbre < A0 + NUM_ANALOG_INPUTS) {
-         analog_channel = pin_nbre - A0;
-       } else if (pin_nbre >= 0 && pin_nbre < NUM_ANALOG_INPUTS) {
-         analog_channel = pin_nbre;
-         pin_nbre = A0 + pin_nbre;
-       }
-
-       if (analog_channel >= 0) {
-         int a_value = analogRead(analog_channel);
-         SERIAL_PRINT_PGM("Analog value on pin ");
-         printPin(pin_nbre);
-         printStrDec(": ", a_value);
-         SERIAL_PRINT_PGM(" / ");
-         Serial.print(a_value / 1023.0f * VCC);
-         SERIAL_PRINTLN_PGM("V");
-       } else {
-         SERIAL_PRINT_PGM("Pin ");
-         if (pin_nbre >= 0) {
-           printPin(pin_nbre);
-         } else {
-           SERIAL_PRINT_PGM("invalid");
+       if (tolower(pollPeek()) == 'a') {
+         pollSerial(); // consume second 'a'
+         pollBlanks();
+         int interval = 0;
+         if (isNumberPeek()) {
+           interval = pollInt();
          }
-         SERIAL_PRINTLN_PGM(" does not support analog input");
+         Serial.println();
+         while (!Serial.available()) {
+           unsigned long start_ms = millis();
+           for (int i = 0; i < NUM_ANALOG_INPUTS; i++) {
+             Serial.print(analogRead(i));
+             Serial.print(';');
+           }
+           Serial.println();
+           if (interval > 0) {
+             while (millis() - start_ms < (unsigned long)interval) {
+               if (Serial.available()) {
+                 break;
+               }
+               delay(1);
+             }
+           }
+         }
+         if (Serial.available()) {
+           Serial.read(); // consume the character that stopped the loop
+         }
+       } else {
+         Serial.println();
+         int pin_nbre = pollPin();
+         int analog_channel = -1;
+         if (pin_nbre >= A0 && pin_nbre < A0 + NUM_ANALOG_INPUTS) {
+           analog_channel = pin_nbre - A0;
+         } else if (pin_nbre >= 0 && pin_nbre < NUM_ANALOG_INPUTS) {
+           analog_channel = pin_nbre;
+           pin_nbre = A0 + pin_nbre;
+         }
+
+         if (analog_channel >= 0) {
+           int a_value = analogRead(analog_channel);
+           SERIAL_PRINT_PGM("Analog value on pin ");
+           printPin(pin_nbre);
+           printStrDec(": ", a_value);
+           SERIAL_PRINT_PGM(" / ");
+           Serial.print(a_value / 1023.0f * VCC);
+           SERIAL_PRINTLN_PGM("V");
+         } else {
+           SERIAL_PRINT_PGM("Pin ");
+           if (pin_nbre >= 0) {
+             printPin(pin_nbre);
+           } else {
+             SERIAL_PRINT_PGM("invalid");
+           }
+           SERIAL_PRINTLN_PGM(" does not support analog input");
+         }
        }
      }
     break;


### PR DESCRIPTION
Implemented continuous analog reading via the newly added 'aa' command in MiniPirate. The command accepts an optional interval parameter in milliseconds (or defaults to best effort if omitted). It continuously prints all available analog channel values formatted with semicolons until any serial input is received. Updated mpHelp() help menu and the README.md documentation accordingly. Verified compilation for Arduino Uno.

Fixes #28

---
*PR created automatically by Jules for task [15764895659979543978](https://jules.google.com/task/15764895659979543978) started by @chatelao*