### PR TITLE
Implement CLI "ar" command to change ADC resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A simple commandline to scan I2C, read/write GPIO, read/write EEPROM and read CP
 | `c` | Set port to clock high and low with given duration | `c 8 100` (clocks pin 8 with 100ms duration)|
 | `a` | Analog reading | `a 0` or `a a0` (reads analog value from pin A0) |
 | `aa` | Continuous analog reading | `aa` or `aa 100` (continuous reading of analog values) |
+| `ar` | Set ADC resolution (or show if no value) | `ar 12` (sets ADC resolution to 12 bits) |
 | `g` | Set analog (pwm) value | `g 9 128` (sets PWM on pin 9 to 128)|
 | `s` | Set servo value | `s 10 90` (sets servo on pin 10 to 90 degrees)|
 | `\A2/A3`| Set Pin A2 to low, Pin A3 to high (and both to output) | `\A2/A3` |

--- a/examples/Minipirate/Minipirate.ino
+++ b/examples/Minipirate/Minipirate.ino
@@ -64,6 +64,7 @@ int freeRam();
 bool checkPinIsOutputMode( int pin_nbre );
 
 
+int adc_resolution = 10;
 float VCC;
 #ifndef ESP8266
 Servo     servo;
@@ -110,6 +111,7 @@ void mpHelp() {
   // Serial.println("b - Show bar graph of analog input");
   SERIAL_PRINTLN_PGM("a - Analog reading");
   SERIAL_PRINTLN_PGM("aa - Continuous analog reading");
+  SERIAL_PRINTLN_PGM("ar - Set ADC resolution (or show if no value)");
   SERIAL_PRINTLN_PGM("g - Set analog (pwm) value");
 
   SERIAL_PRINTLN_PGM("s - Set servo value");
@@ -409,6 +411,28 @@ void loop()
          if (Serial.available()) {
            Serial.read(); // consume the character that stopped the loop
          }
+       } else if (tolower(pollPeek()) == 'r') {
+         pollSerial(); // consume second 'r'
+         pollBlanks();
+         if (isNumberPeek()) {
+           int res = pollInt();
+#if !defined(__AVR__) && !defined(ESP8266)
+           analogReadResolution(res);
+           adc_resolution = res;
+           Serial.println();
+           SERIAL_PRINT_PGM("ADC resolution set to ");
+           Serial.print(adc_resolution);
+           SERIAL_PRINTLN_PGM(" bits");
+#else
+           Serial.println();
+           SERIAL_PRINTLN_PGM("Not supported on this chip");
+#endif
+         } else {
+           Serial.println();
+           SERIAL_PRINT_PGM("ADC resolution: ");
+           Serial.print(adc_resolution);
+           SERIAL_PRINTLN_PGM(" bits");
+         }
        } else {
          Serial.println();
          int pin_nbre = pollPin();
@@ -426,7 +450,7 @@ void loop()
            printPin(pin_nbre);
            printStrDec(": ", a_value);
            SERIAL_PRINT_PGM(" / ");
-           Serial.print(a_value / 1023.0f * VCC);
+           Serial.print(a_value / (float)((1 << adc_resolution) - 1) * VCC);
            SERIAL_PRINTLN_PGM("V");
          } else {
            SERIAL_PRINT_PGM("Pin ");

--- a/examples/Minipirate/baseIO.cpp
+++ b/examples/Minipirate/baseIO.cpp
@@ -879,7 +879,7 @@ void printPorts() {
          printStrDec(" / ", a_value,3);
 		 SERIAL_PRINT_PGM(" / ");
 		 extern float VCC;
-		 Serial.print(a_value / 1023.0f * VCC);
+		 Serial.print(a_value / (float)((1 << adc_resolution) - 1) * VCC);
 		 SERIAL_PRINT_PGM("V");
      //    printStrDec(" / ", a_value);
          Serial.println();

--- a/examples/Minipirate/baseIO.h
+++ b/examples/Minipirate/baseIO.h
@@ -176,6 +176,8 @@ void printPin(int pin);
 void printPorts();
 void printPortsQuick();
 
+extern int adc_resolution;
+
 inline int getPinMode( int i )
 	{
 	return *portModeRegister(digitalPinToPort(i)) & digitalPinToBitMask(i);


### PR DESCRIPTION
Implemented the CLI `ar` command for managing ADC resolution. This includes:
- Storing the current ADC resolution dynamically (defaulting to 10 bits).
- Conditionally compiling `analogReadResolution()` for platforms that support it (like RP2040 and RP2350), while printing a fallback message on AVR and other platforms.
- Replacing the hardcoded 1023 divisor in voltage conversions with `(1 << adc_resolution) - 1`.
- Documenting the new `ar` command in both the help menu and README.md.

Fixes #34

---
*PR created automatically by Jules for task [17668240562567234443](https://jules.google.com/task/17668240562567234443) started by @chatelao*