### PR TITLE
Generate .uf2 / .hex / .bin assets for every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release Assets
+
+on:
+  release:
+    types: [published, created]
+
+permissions:
+  contents: write
+
+jobs:
+  release-assets:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Arduino CLI
+        uses: arduino/setup-arduino-cli@v2
+
+      - name: Install platform and libraries
+        run: |
+          arduino-cli core update-index --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+          arduino-cli core install arduino:avr
+          arduino-cli core install rp2040:rp2040 --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+          arduino-cli lib install Servo
+
+      - name: Link library
+        run: |
+          mkdir -p $HOME/Arduino/libraries
+          ln -s $GITHUB_WORKSPACE $HOME/Arduino/libraries/MiniPirate
+
+      - name: Compile Sketch
+        run: |
+          arduino-cli compile --fqbn arduino:avr:uno -e examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn rp2040:rp2040:rpipico -e examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn rp2040:rp2040:rpipico2 -e examples/Minipirate/Minipirate.ino
+
+      - name: Prepare Release Assets
+        run: |
+          mkdir -p assets
+          cp examples/Minipirate/build/arduino.avr.uno/Minipirate.ino.hex assets/Minipirate-uno.hex
+          cp examples/Minipirate/build/arduino.avr.uno/Minipirate.ino.with_bootloader.hex assets/Minipirate-uno-with_bootloader.hex
+          cp examples/Minipirate/build/rp2040.rp2040.rpipico/Minipirate.ino.bin assets/Minipirate-rpipico.bin
+          cp examples/Minipirate/build/rp2040.rp2040.rpipico/Minipirate.ino.uf2 assets/Minipirate-rpipico.uf2
+          cp examples/Minipirate/build/rp2040.rp2040.rpipico2/Minipirate.ino.bin assets/Minipirate-rpipico2.bin
+          cp examples/Minipirate/build/rp2040.rp2040.rpipico2/Minipirate.ino.uf2 assets/Minipirate-rpipico2.uf2
+
+      - name: Upload Release Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            assets/Minipirate-uno.hex
+            assets/Minipirate-uno-with_bootloader.hex
+            assets/Minipirate-rpipico.bin
+            assets/Minipirate-rpipico.uf2
+            assets/Minipirate-rpipico2.bin
+            assets/Minipirate-rpipico2.uf2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Arduino CLI build artifacts
+examples/Minipirate/build/
+arduino-cli


### PR DESCRIPTION
Added `.github/workflows/release.yml` to compile and upload `.hex`, `.bin`, and `.uf2` assets for the Arduino Uno, Raspberry Pi Pico, and Raspberry Pi Pico 2 boards whenever a new release is published. Also added a `.gitignore` file to ensure local build artifacts do not get committed.

Fixes #35

---
*PR created automatically by Jules for task [2915588666875193709](https://jules.google.com/task/2915588666875193709) started by @chatelao*