### PR TITLE
Add support for G431 and F446 re boards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,10 @@ jobs:
 
       - name: Install platform and libraries
         run: |
-          arduino-cli core update-index --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+          arduino-cli core update-index --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
           arduino-cli core install arduino:avr
           arduino-cli core install rp2040:rp2040 --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+          arduino-cli core install STMicroelectronics:stm32 --additional-urls https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
           arduino-cli lib install Servo
 
       - name: Link library
@@ -30,3 +31,5 @@ jobs:
           arduino-cli compile --fqbn arduino:avr:uno examples/Minipirate/Minipirate.ino
           arduino-cli compile --fqbn rp2040:rp2040:rpipico examples/Minipirate/Minipirate.ino
           arduino-cli compile --fqbn rp2040:rp2040:rpipico2 examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_G431RB examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_F446RE examples/Minipirate/Minipirate.ino


### PR DESCRIPTION
Added board manager index for STMicroelectronics stm32 core and compilation steps for Nucleo-G431RB and Nucleo-F446RE boards in the GitHub Actions workflow build.yml. No codebase modifications were required as the sketch compiled flawlessly for these platforms out of the box.

Fixes #36

---
*PR created automatically by Jules for task [3587943093736692293](https://jules.google.com/task/3587943093736692293) started by @chatelao*