### PR TITLE
Add Seeed XIAO RP2040 and RP2350 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,5 +31,7 @@ jobs:
           arduino-cli compile --fqbn arduino:avr:uno examples/Minipirate/Minipirate.ino
           arduino-cli compile --fqbn rp2040:rp2040:rpipico examples/Minipirate/Minipirate.ino
           arduino-cli compile --fqbn rp2040:rp2040:rpipico2 examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn rp2040:rp2040:seeed_xiao_rp2040 examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn rp2040:rp2040:seeed_xiao_rp2350 examples/Minipirate/Minipirate.ino
           arduino-cli compile --fqbn STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_G431RB examples/Minipirate/Minipirate.ino
           arduino-cli compile --fqbn STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_F446RE examples/Minipirate/Minipirate.ino

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
           arduino-cli compile --fqbn arduino:avr:uno -e examples/Minipirate/Minipirate.ino
           arduino-cli compile --fqbn rp2040:rp2040:rpipico -e examples/Minipirate/Minipirate.ino
           arduino-cli compile --fqbn rp2040:rp2040:rpipico2 -e examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn rp2040:rp2040:seeed_xiao_rp2040 -e examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn rp2040:rp2040:seeed_xiao_rp2350 -e examples/Minipirate/Minipirate.ino
 
           # STM32 NUCLEO-G431RB
           arduino-cli compile --fqbn STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_G431RB -e examples/Minipirate/Minipirate.ino
@@ -58,6 +60,10 @@ jobs:
           cp examples/Minipirate/build/rp2040.rp2040.rpipico/Minipirate.ino.uf2 assets/Minipirate-rpipico.uf2
           cp examples/Minipirate/build/rp2040.rp2040.rpipico2/Minipirate.ino.bin assets/Minipirate-rpipico2.bin
           cp examples/Minipirate/build/rp2040.rp2040.rpipico2/Minipirate.ino.uf2 assets/Minipirate-rpipico2.uf2
+          cp examples/Minipirate/build/rp2040.rp2040.seeed_xiao_rp2040/Minipirate.ino.bin assets/Minipirate-xiao_rp2040.bin
+          cp examples/Minipirate/build/rp2040.rp2040.seeed_xiao_rp2040/Minipirate.ino.uf2 assets/Minipirate-xiao_rp2040.uf2
+          cp examples/Minipirate/build/rp2040.rp2040.seeed_xiao_rp2350/Minipirate.ino.bin assets/Minipirate-xiao_rp2350.bin
+          cp examples/Minipirate/build/rp2040.rp2040.seeed_xiao_rp2350/Minipirate.ino.uf2 assets/Minipirate-xiao_rp2350.uf2
           cp examples/Minipirate/build/STMicroelectronics.stm32.Nucleo_64-g431rb/Minipirate.ino.bin assets/Minipirate-nucleo_g431rb.bin
           cp examples/Minipirate/build/STMicroelectronics.stm32.Nucleo_64-g431rb/Minipirate.ino.hex assets/Minipirate-nucleo_g431rb.hex
           cp examples/Minipirate/build/STMicroelectronics.stm32.Nucleo_64-f446re/Minipirate.ino.bin assets/Minipirate-nucleo_f446re.bin
@@ -73,6 +79,10 @@ jobs:
             assets/Minipirate-rpipico.uf2
             assets/Minipirate-rpipico2.bin
             assets/Minipirate-rpipico2.uf2
+            assets/Minipirate-xiao_rp2040.bin
+            assets/Minipirate-xiao_rp2040.uf2
+            assets/Minipirate-xiao_rp2350.bin
+            assets/Minipirate-xiao_rp2350.uf2
             assets/Minipirate-nucleo_g431rb.bin
             assets/Minipirate-nucleo_g431rb.hex
             assets/Minipirate-nucleo_f446re.bin

--- a/examples/Minipirate/Minipirate.ino
+++ b/examples/Minipirate/Minipirate.ino
@@ -24,18 +24,14 @@
 
 #include <ctype.h>
 #include <Wire.h>
+#include "baseIO.h"
 #ifdef __AVR__
 #include <EEPROM.h>
-#else
-#ifndef NUM_DIGITAL_PINS
-#define NUM_DIGITAL_PINS 10
-#endif
 #endif
 #ifndef ESP8266
 #include <Servo.h>
 #endif
 #include "pins_arduino.h"
-#include "baseIO.h"
 #include "modeBase.h"
 #include "modeI2C.h"
 #include "Strings_PGM_MEM.h"

--- a/examples/Minipirate/baseIO.h
+++ b/examples/Minipirate/baseIO.h
@@ -22,6 +22,14 @@
 #else
 #include "WProgram.h"
 #endif
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 30
+#endif
+#ifndef NUM_ANALOG_INPUTS
+#define NUM_ANALOG_INPUTS 4
+#endif
+
 /*
 //manage user terminal input
 unsigned int bpUserNumberPrompt(unsigned int maxBytes, unsigned int maxValue, unsigned int defValue);


### PR DESCRIPTION
This submission adds Seeed Studio XIAO RP2040 and XIAO RP2350 boards to the CI test build and automated release asset pipelines. It also resolves a compilation error by providing robust fallbacks for pin limits when they are not defined by the variant.

Fixes #45

---
*PR created automatically by Jules for task [8917627864142289877](https://jules.google.com/task/8917627864142289877) started by @chatelao*