### PR TITLE
Add Seeed Studio XIAO RA4M1 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,11 @@ jobs:
 
       - name: Install platform and libraries
         run: |
-          arduino-cli core update-index --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
+          arduino-cli core update-index --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json,https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
           arduino-cli core install arduino:avr
           arduino-cli core install rp2040:rp2040 --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
           arduino-cli core install STMicroelectronics:stm32 --additional-urls https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
+          arduino-cli core install Seeeduino:renesas_uno --additional-urls https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
           arduino-cli lib install Servo
 
       - name: Link library
@@ -33,3 +34,4 @@ jobs:
           arduino-cli compile --fqbn rp2040:rp2040:rpipico2 examples/Minipirate/Minipirate.ino
           arduino-cli compile --fqbn STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_G431RB examples/Minipirate/Minipirate.ino
           arduino-cli compile --fqbn STMicroelectronics:stm32:Nucleo_64:pnum=NUCLEO_F446RE examples/Minipirate/Minipirate.ino
+          arduino-cli compile --fqbn Seeeduino:renesas_uno:XIAO_RA4M1 examples/Minipirate/Minipirate.ino

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,11 @@ jobs:
 
       - name: Install platform and libraries
         run: |
-          arduino-cli core update-index --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
+          arduino-cli core update-index --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json,https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json,https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
           arduino-cli core install arduino:avr
           arduino-cli core install rp2040:rp2040 --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
           arduino-cli core install STMicroelectronics:stm32 --additional-urls https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
+          arduino-cli core install Seeeduino:renesas_uno --additional-urls https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
           arduino-cli lib install Servo
 
       - name: Link library
@@ -49,6 +50,9 @@ jobs:
           cp examples/Minipirate/build/STMicroelectronics.stm32.Nucleo_64/Minipirate.ino.bin examples/Minipirate/build/STMicroelectronics.stm32.Nucleo_64-f446re/
           cp examples/Minipirate/build/STMicroelectronics.stm32.Nucleo_64/Minipirate.ino.hex examples/Minipirate/build/STMicroelectronics.stm32.Nucleo_64-f446re/
 
+          # XIAO RA4M1
+          arduino-cli compile --fqbn Seeeduino:renesas_uno:XIAO_RA4M1 -e examples/Minipirate/Minipirate.ino
+
       - name: Prepare Release Assets
         run: |
           mkdir -p assets
@@ -62,6 +66,8 @@ jobs:
           cp examples/Minipirate/build/STMicroelectronics.stm32.Nucleo_64-g431rb/Minipirate.ino.hex assets/Minipirate-nucleo_g431rb.hex
           cp examples/Minipirate/build/STMicroelectronics.stm32.Nucleo_64-f446re/Minipirate.ino.bin assets/Minipirate-nucleo_f446re.bin
           cp examples/Minipirate/build/STMicroelectronics.stm32.Nucleo_64-f446re/Minipirate.ino.hex assets/Minipirate-nucleo_f446re.hex
+          cp examples/Minipirate/build/Seeeduino.renesas_uno.XIAO_RA4M1/Minipirate.ino.bin assets/Minipirate-xiao_ra4m1.bin
+          cp examples/Minipirate/build/Seeeduino.renesas_uno.XIAO_RA4M1/Minipirate.ino.hex assets/Minipirate-xiao_ra4m1.hex
 
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2
@@ -77,3 +83,5 @@ jobs:
             assets/Minipirate-nucleo_g431rb.hex
             assets/Minipirate-nucleo_f446re.bin
             assets/Minipirate-nucleo_f446re.hex
+            assets/Minipirate-xiao_ra4m1.bin
+            assets/Minipirate-xiao_ra4m1.hex

--- a/examples/Minipirate/Minipirate.ino
+++ b/examples/Minipirate/Minipirate.ino
@@ -44,7 +44,11 @@
 
 #define BAUD_RATE 57600
 
+#if defined(A0) && (A0 > 0)
 #define ALLPINS (NUM_ANALOG_INPUTS+A0)
+#else
+#define ALLPINS NUM_DIGITAL_PINS
+#endif
 
 // multipled by 1023 since that's the resolution of the ADC
 #if defined(__AVR_ATmega8__)

--- a/examples/Minipirate/baseIO.cpp
+++ b/examples/Minipirate/baseIO.cpp
@@ -846,7 +846,8 @@ void printPin(int pin) {
 }
 
 void printPorts() {
-       for(int i = 0; i < A0; i++) {
+       int limit = (A0 == 0) ? NUM_DIGITAL_PINS : A0;
+       for(int i = 0; i < limit; i++) {
          int value = digitalRead(i);
 
          SERIAL_PRINT_PGM("Value on pin D");
@@ -892,7 +893,8 @@ void printPorts() {
 // Prints all port direction and values in a matrix (concise) format
 // Digital values are 8 across and analog are 4 across
 void printPortsQuick() {
-	for(int i = 0; i < A0; i++) {
+	int limit = (A0 == 0) ? NUM_DIGITAL_PINS : A0;
+	for(int i = 0; i < limit; i++) {
 		int value = digitalRead(i);
 		if (i%8==0) {
 			SERIAL_PRINT_PGM("D");

--- a/examples/Minipirate/baseIO.h
+++ b/examples/Minipirate/baseIO.h
@@ -22,6 +22,15 @@
 #else
 #include "WProgram.h"
 #endif
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 10
+#endif
+
+#ifndef NUM_ANALOG_INPUTS
+#define NUM_ANALOG_INPUTS 6
+#endif
+
 /*
 //manage user terminal input
 unsigned int bpUserNumberPrompt(unsigned int maxBytes, unsigned int maxValue, unsigned int defValue);


### PR DESCRIPTION
This PR adds comprehensive support for the Seeed Studio XIAO RA4M1 board. It implements safe pin fallback handling in the Arduino sketch to support boards where A0 is 0 (mapping to D0), adds Seeeduino:renesas_uno core installation and build steps to the CI build workflow, and packages/uploads release assets (.bin and .hex) to GitHub releases.

Fixes #46

---
*PR created automatically by Jules for task [8046641991694868268](https://jules.google.com/task/8046641991694868268) started by @chatelao*