### PR TITLE
Remove redundant Example column from General Commands table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ A simple commandline to scan I2C, read/write GPIO, read/write EEPROM and read CP
 
 ### General Commands
 
-| Command | Description | Example | Output Example |
-|---|---|---|---|
-| `h` / `?` | Show this help | `h` | (help text) |
-| `v` | Show AVR VCC reading | `v` | `VCC: 5012mV` |
-| `t` | Show AVR internal temperature reading | `t` | `Temp: 25.4C`|
-| `f` | Show free memory | `f` | `Mem: 1234` |
-| `u` | Show system uptime (or clock) | `u` | `Uptime: 12345ms` |
-| `e` | Erase EEPROM | `e` | `EEPROM erased` |
-| `*` | Reboot | `*` | `Rebooting...` |
-| `x` | save current config to eeprom | `x` | `saved` |
-| `y` | load last config from eeprom | `y` | `loaded` |
+| Command | Description | Output Example |
+|---|---|---|
+| `h` / `?` | Show this help | (help text) |
+| `v` | Show AVR VCC reading | `VCC: 5012mV` |
+| `t` | Show AVR internal temperature reading | `Temp: 25.4C`|
+| `f` | Show free memory | `Mem: 1234` |
+| `u` | Show system uptime (or clock) | `Uptime: 12345ms` |
+| `e` | Erase EEPROM | `EEPROM erased` |
+| `*` | Reboot | `Rebooting...` |
+| `x` | save current config to eeprom | `saved` |
+| `y` | load last config from eeprom | `loaded` |
 
 ### GPIO Commands
 


### PR DESCRIPTION
This pull request removes the redundant "Example" column from the "General Commands" table in `README.md`. Since the commands are single characters and identical to what is in the "Command" column, having a separate "Example" column was redundant. The table has been simplified to contain "Command", "Description", and "Output Example".

Fixes #58

---
*PR created automatically by Jules for task [4888959914496910995](https://jules.google.com/task/4888959914496910995) started by @chatelao*