### PR TITLE
Fix PWM capabilities detection on RP2040 and RP2350 platforms

### DIFF
--- a/examples/Minipirate/baseIO.h
+++ b/examples/Minipirate/baseIO.h
@@ -30,6 +30,12 @@
 #define NUM_ANALOG_INPUTS 4
 #endif
 
+#ifndef digitalPinHasPWM
+#if defined(ARDUINO_ARCH_RP2040)
+#define digitalPinHasPWM(p) ((p) < NUM_DIGITAL_PINS)
+#endif
+#endif
+
 /*
 //manage user terminal input
 unsigned int bpUserNumberPrompt(unsigned int maxBytes, unsigned int maxValue, unsigned int defValue);


### PR DESCRIPTION
Fixes the PWM implementation check on RP2040/RP2350 boards by defining the missing `digitalPinHasPWM` macro in baseIO.h. Since the Earle Philhower arduino-pico core does not define this macro, the 'g' (PWM output) command and 'p' (detailed port status) commands were incorrectly falling back to indicating that PWM is not supported on any pins of RP2040. Defining `digitalPinHasPWM(p)` as `((p) < NUM_DIGITAL_PINS)` on `ARDUINO_ARCH_RP2040` correctly registers all digital pins on the RP2040 as PWM-capable.

Fixes #57

---
*PR created automatically by Jules for task [6213330608570208024](https://jules.google.com/task/6213330608570208024) started by @chatelao*