### PR TITLE
Split GPIO Commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A simple commandline to scan I2C, read/write GPIO, read/write EEPROM and read CP
 | `x` | save current config to eeprom | `saved` |
 | `y` | load last config from eeprom | `loaded` |
 
-### GPIO Commands
+### Digital GPIO Commands
 
 | Command | Description | Example |
 |---|---|---|
@@ -31,13 +31,18 @@ A simple commandline to scan I2C, read/write GPIO, read/write EEPROM and read CP
 | `^` | Set a port LOW-HIGH-LOW (one clock) | `^ 7` (sends a clock pulse to pin 7) |
 | `$` | Do a pin sweep | `$` |
 | `c` | Set port to clock high and low with given duration | `c 8 100` (clocks pin 8 with 100ms duration)|
+| `\A2/A3`| Set Pin A2 to low, Pin A3 to high (and both to output) | `\A2/A3` |
+| `z` | set all ports to input and low | `z` |
+
+### Analog & PWM Commands
+
+| Command | Description | Example |
+|---|---|---|
 | `a` | Analog reading | `a 0` or `a a0` (reads analog value from pin A0) |
 | `aa` | Continuous analog reading | `aa` or `aa 100` (continuous reading of analog values) |
 | `ar` | Set ADC resolution (or show if no value) | `ar 12` (sets ADC resolution to 12 bits) |
 | `g` | Set analog (pwm) value | `g 9 128` (sets PWM on pin 9 to 128)|
 | `s` | Set servo value | `s 10 90` (sets servo on pin 10 to 90 degrees)|
-| `\A2/A3`| Set Pin A2 to low, Pin A3 to high (and both to output) | `\A2/A3` |
-| `z` | set all ports to input and low | `z` |
 
 
 ### I2C Commands


### PR DESCRIPTION
This change updates the README.md to split the single "GPIO Commands" table/section into two logically distinct sections: "Digital GPIO Commands" and "Analog & PWM Commands". This improves readability and organization of the commands for users.

Fixes #62

---
*PR created automatically by Jules for task [5236202218262900943](https://jules.google.com/task/5236202218262900943) started by @chatelao*